### PR TITLE
Disable `libev` indiscriminate child reaping

### DIFF
--- a/oxide/build.sh
+++ b/oxide/build.sh
@@ -55,7 +55,7 @@ function configure_build {
         # We only want to build the sidecar code on helios
         BSP=OFF
         LINKER_FLAGS=""
-	BOOST_ROOT=""
+        BOOST_ROOT=""
         BOOST_DIR=/usr/include
         BOOST_STATIC=OFF
         CXX_FLAGS="-I${SDE}/oxide/rapidjson/include"
@@ -68,10 +68,16 @@ function configure_build {
         BOOST_STATIC=ON
         CXX_FLAGS="-D__EXTENSIONS__ -I${SDE}/oxide/rapidjson/include"
         C_FLAGS="-D__EXTENSIONS__ -D_POSIX_PTHREAD_SEMANTICS"
-	# To pick up realpath and the pip installed pyinstaller.
-	# XXX: this should be part of the CI controller, not here
-	PATH=${PATH}:~/.local/bin:/usr/gnu/bin
+        # To pick up realpath and the pip installed pyinstaller.
+        # XXX: this should be part of the CI controller, not here
+	    PATH=${PATH}:~/.local/bin:/usr/gnu/bin
     fi
+
+    # Disable the libev SIGCHLD handler which reaps all children
+    # unconditionally. We need both language flags, because the library is
+    # compiled as a pure C library, but the actual Tofino software that includes
+    # it is technically C++.
+    #EXTRA_FLAGS="-DEV_CHILD_ENABLE=0"
 
     cd ${SDE}/build
     cmake $SDE \
@@ -95,15 +101,16 @@ function configure_build {
         -DRAPIDJSON_DIR=$RAPIDJSON_DIR/include \
         -DP4C_USE_PREINSTALLED_ABSEIL=ON \
         -DP4C_USE_PREINSTALLED_PROTOBUF=OFF \
-	${BOOST_ROOT} \
+        ${BOOST_ROOT} \
         -DBoost_INCLUDE_DIRS=${BOOST_DIR} \
-	-DBoost_USE_STATIC_RUNTIME=$BOOST_STATIC \
+        -DBoost_USE_STATIC_RUNTIME=$BOOST_STATIC \
         -DCMAKE_BUILD_TYPE='Release' \
         -DCMAKE_LINKER='lld' \
         -DCMAKE_INSTALL_PREFIX=$SDE/install \
         -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \
         -DCMAKE_EXE_LINKER_FLAGS="$LINKER_FLAGS" \
-        -DCMAKE_C_FLAGS="$C_FLAGS"
+        -DCMAKE_C_FLAGS="$C_FLAGS" \
+        -DLIBEV_EV_CHILD_ENABLE=0
 }
 
 function build {

--- a/oxide/build.sh
+++ b/oxide/build.sh
@@ -73,12 +73,6 @@ function configure_build {
 	    PATH=${PATH}:~/.local/bin:/usr/gnu/bin
     fi
 
-    # Disable the libev SIGCHLD handler which reaps all children
-    # unconditionally. We need both language flags, because the library is
-    # compiled as a pure C library, but the actual Tofino software that includes
-    # it is technically C++.
-    #EXTRA_FLAGS="-DEV_CHILD_ENABLE=0"
-
     cd ${SDE}/build
     cmake $SDE \
         -DASIC=ON  \

--- a/pkgsrc/target-syslibs/CMakeLists.txt
+++ b/pkgsrc/target-syslibs/CMakeLists.txt
@@ -16,6 +16,9 @@ set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/ConfigureChecks.cmake)
 
+if(DEFINED LIBEV_EV_CHILD_ENABLE)
+    add_compile_definitions(EV_CHILD_ENABLE=${LIBEV_EV_CHILD_ENABLE})
+endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/third-party)

--- a/pkgsrc/target-syslibs/third-party/libev/CMakeLists.txt
+++ b/pkgsrc/target-syslibs/third-party/libev/CMakeLists.txt
@@ -4,3 +4,7 @@ set(CMAKE_C_FLAGS "-g -O3 -w")
 
 add_library(ev_o OBJECT ev.c ev.h ev++.h)
 add_library(ev SHARED EXCLUDE_FROM_ALL $<TARGET_OBJECTS:ev_o>)
+
+if(DEFINED LIBEV_EV_CHILD_ENABLE)
+    target_compile_definitions(ev_o PRIVATE EV_CHILD_ENABLE=${LIBEV_EV_CHILD_ENABLE})
+endif()


### PR DESCRIPTION
The `libev` third-party dependency is automatically built with a compiler flag that causes it to accept `SIGCHLD` and indiscriminately call `waitpid(-1)`, i.e., reap any child processes that are currently finished. This means no other code in the whole process can spawn and wait on that child without racing this handler.

This commit adds a build flag `LIBEV_EV_CHILD_ENABLE` that controls this throughout the build, and sets it to 0 in our `oxide/build.sh` top-level script.